### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+sudo: false
+
+matrix:
+  include:
+    - php: 7.2
+    - php: 7.4
+    - php: nightly
+      env:
+       - COMPOSER_ARG="--ignore-platform-reqs"
+
+before_install:
+  - composer install $COMPOSER_ARG
+
+script:
+  - composer test

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"issues": "https://github.com/oscarotero/html-parser/issues"
 	},
 	"require": {
-		"php": ">=7.2"
+		"php": "^7.2 || ^8"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -75,13 +75,20 @@ class Parser
     private static function createDOMDocument(string $code): DOMDocument
     {
         $errors = libxml_use_internal_errors(true);
-        $entities = libxml_disable_entity_loader(true);
+        
+        // Enabled by default in PHP 8
+        if (PHP_MAJOR_VERSION < 8) {
+            $entities = libxml_disable_entity_loader(true);
+        }
 
         $document = new DOMDocument();
         $document->loadHTML($code);
 
         libxml_use_internal_errors($errors);
-        libxml_disable_entity_loader($entities);
+
+        if (PHP_MAJOR_VERSION < 8) {
+            libxml_disable_entity_loader($entities);
+        }
 
         return $document;
     }

--- a/tests/HtmlParserTest.php
+++ b/tests/HtmlParserTest.php
@@ -26,11 +26,9 @@ class HtmlParserTest extends TestCase
     {
         $html = <<<HTML
 <!DOCTYPE html>
-<html>
-    <body>
+<html><body>
         <img src="http://example.com/image.png?123456" alt="Image">
-    </body>
-</html>
+</body></html>
 HTML;
 
         $document = Parser::parse($html);


### PR DESCRIPTION
This adds a travis.yml and makes a small change necessary for PHP 8 support.

The build can be seen here https://travis-ci.org/github/sminnee/html-parser/builds/722600233 but it would be good to enable travis directly on this repo once this has been merged.