### PR TITLE
Use mb_encode_numericentity() for PHP 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
     - php: 7.2
     - php: 7.4
+    - php: 8.1
     - php: nightly
       env:
        - COMPOSER_ARG="--ignore-platform-reqs"

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -26,7 +26,7 @@ class Parser
         $detected = $encoding ?? mb_detect_encoding($html);
         
         if ($detected) {
-            $html = mb_convert_encoding($html, 'HTML-ENTITIES', $detected);
+            $html = mb_encode_numericentity($html, [0x80, 0xFFFFFF, 0, -1], $detected);
         }
 
         $document = self::createDOMDocument($html);


### PR DESCRIPTION
Fixes the following deprecation in PHP 8.2

`Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in /home/runner/work/silverstripe-installer/silverstripe-installer/vendor/oscarotero/html-parser/src/Parser.php on line 29`

https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated

I noticed this issue because html-parser is a requirement of https://github.com/oscarotero/embed which we use in our open source project

I've also added PHP 8.1 to the travis matrix with the assumption that 'nightly' will become PHP 8.2

@oscarotero Would you be able to tag 0.1.7 once this is merged. Thank you