### PR TITLE
fixed libxml internal buffer leak

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -90,6 +90,10 @@ class Parser
             libxml_disable_entity_loader($entities);
         }
 
+        if (libxml_get_last_error() !== false) {
+            libxml_clear_errors();
+        }
+
         return $document;
     }
 }


### PR DESCRIPTION
`libxml_use_internal_errors(true)` starts to write errors to an internal buffer. That buffer should be cleared after usage.

[The documentation of `libxml_use_internal_errors`](https://www.php.net/manual/en/function.libxml-use-internal-errors.php) says:

> [...] Disabling will also clear any existing libxml errors.

But this does not seem to be true. However, the top "User Contributed Notes" says the following:

> When using this funtion, be sure to clear your internal error buffer. If you dn't and you are using this in a long running process, you may find that all your memory is used up.

The solution is to call `libxml_clear_errors` after using the internal error buffer.