### PR TITLE
Make nullable parameter explicity nullable for PHP 8.4

### DIFF
--- a/tests/EncodingsTest.php
+++ b/tests/EncodingsTest.php
@@ -63,7 +63,7 @@ class EncodingsTest extends TestCase
     /**
      * @dataProvider encodingDataProvider
      */
-    public function testRussian(string $file, string $title, string $description = null, string $metaName = 'description', string $encoding = null)
+    public function testRussian(string $file, string $title, ?string $description = null, string $metaName = 'description', ?string $encoding = null)
     {
         $document = Parser::parse(\file_get_contents(__DIR__."/assets/{$file}"), $encoding);
         $titleElement = $document->getElementsByTagName('title')->item(0);


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter